### PR TITLE
Try to add code from picture

### DIFF
--- a/src/components/ExploreContainer.tsx
+++ b/src/components/ExploreContainer.tsx
@@ -1,12 +1,41 @@
-import './ExploreContainer.css';
+import "./ExploreContainer.css";
 
-interface ContainerProps { }
+declare var OneTrust: any;
 
-const ExploreContainer: React.FC<ContainerProps> = () => {
+interface ContainerProps {
+  c4Status: number;
+}
+
+const ExploreContainer: React.FC<ContainerProps> = ({ c4Status }) => {
   return (
     <div id="container">
-      <strong>Ready to create an app?</strong>
-      <p>Start with Ionic <a target="_blank" rel="noopener noreferrer" href="https://ionicframework.com/docs/components">UI Components</a></p>
+      <button
+        onClick={() => {
+          OneTrust.showBannerUI();
+        }}
+      >
+        Load Banner
+      </button>
+      <button
+        onClick={() => {
+          OneTrust.showPreferenceCenterUI();
+        }}
+      >
+        Load Preference Center
+      </button>
+      <p>
+        The status of categor C0004 is <b>{c4Status}</b>
+      </p>
+      <p>
+        Start with Ionic{" "}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://ionicframework.com/docs/components"
+        >
+          UI Components
+        </a>
+      </p>
     </div>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,10 +7,33 @@ import {
 } from "@ionic/react";
 import ExploreContainer from "../components/ExploreContainer";
 import "./Home.css";
+import { useState } from "react";
 
 declare var OneTrust: any;
+OneTrust.startSDK(
+  "cdn.cookielaw.org",
+  " 5dbf6b9-4546-4651-ac8e-7aa1424bab16-test",
+  "en",
+  null,
+  (downloadStatus: boolean) => {
+    OneTrust.shouldShowBanner((result: boolean) => {
+      if (result && downloadStatus) {
+        OneTrust.showBannerUI();
+      }
+    });
+    OneTrust.getConsentStatusFactory("C0004", (consentStatus: number) => {
+      console.log("The quiered consent status for C0004 is " + consentStatus);
+    });
+  }
+);
 
 const Home: React.FC = () => {
+  const [category4, update] = useState(-1);
+  const updateC4Status = (listenerPayload: any) => {
+    update(listenerPayload.consentStatus);
+  };
+  document.addEventListener("C0004", updateC4Status, false);
+
   console.log("ONETRUST", JSON.stringify(window?.OneTrust ?? {}));
   console.log("ONETRUST", JSON.stringify(OneTrust ?? {}));
   return (
@@ -26,7 +49,7 @@ const Home: React.FC = () => {
             <IonTitle size="large">Blank</IonTitle>
           </IonToolbar>
         </IonHeader>
-        <ExploreContainer />
+        <ExploreContainer c4Status={category4} />
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
**A Guess based on 2 screenshots.**
--- 
Nota: 
It seems that 3 other files where modified (opened in screenshot editor) but not provided: `index.html`, `local.properties`, `plugin.xml`

As the answer was "it's working on my machine", could you please explain:
- Is one of those 3 files to be added/updated,
- How can the `OneTrust` global var have any value as it's never initialized. Hence I continue to get this error message:
```
Home.tsx:13 Uncaught ReferenceError: OneTrust is not defined
```
- isPlatform seems to have been imported (at some point ?) but is not inside the code.


That said, I'm getting One trust logs in the Android logs, so something seems to be loaded on mobile but not in PWA (where we basically develop beacuse HMR is handy). Does this mean this Ionic plugin works **ONLY ON MOBILE?** ...hense the `isPlatform` import ?

Still clicking on buttons does nothing but a log (neither the bannerUI nor the preferenceCenter shows up)
```
2024-01-10 14:54:18.583 12045-12045 Capacitor/Plugin        io.ionic.starter                     V  To native (Cordova plugin): callbackId: INVALID, service: OneTrust, action: showBannerUI, actionArgs: []
2024-01-10 14:54:19.229 12045-12045 Capacitor/Plugin        io.ionic.starter                     V  To native (Cordova plugin): callbackId: INVALID, service: OneTrust, action: showPreferenceCenterUI, actionArgs: []
```

An update, comment, on this PR or repo would really help as transmission through Support team might lead to _time consomption_ and/or _information loss_

Thx for your help.
